### PR TITLE
Update AsyncMail.php

### DIFF
--- a/src/AsyncMail.php
+++ b/src/AsyncMail.php
@@ -10,7 +10,7 @@ class AsyncMail
     {
         $param = base64_encode(serialize($mailable));
         $command = self::createCommandString($param);
-        $process = new Process($command);
+        $process = new Process([$command]);
         $process->run();
     }
 


### PR DESCRIPTION
The Symfony 'new Process' function now requires an array, changed from a string, resulting in this error:

Argument 1 passed to Symfony\Component\Process\Process::__construct() must be of the type array, string given ...